### PR TITLE
Fixed deployment templating for kubePlex.image

### DIFF
--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -26,8 +26,8 @@ spec:
 {{- if .Values.kubePlex.enabled }}
       initContainers:
       - name: kube-plex-install
-        image: "{{ .Values.kubePlexImage.repository }}:{{ .Values.kubePlexImage.tag }}"
-        imagePullPolicy: {{ .Values.kubePlexImage.pullPolicy }}
+        image: "{{ .Values.kubePlex.image.repository }}:{{ .Values.kubePlex.image.tag }}"
+        imagePullPolicy: {{ .Values.kubePlex.image.pullPolicy }}
         command:
         - cp
         - /kube-plex


### PR DESCRIPTION
Deployment fails with templating error due to incorrect key identifier in `deployment.yaml` for `kubePlexImage.repository`, `kubePlexImage.tag` and `kubePlexImage.pullPolicy`.

I've updated the key to `kubePlex.image.*` and it's working again.

M