### PR TITLE
Fixed: Deployment template was looking for kubePlexImage

### DIFF
--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -26,8 +26,8 @@ spec:
 {{- if .Values.kubePlex.enabled }}
       initContainers:
       - name: kube-plex-install
-        image: "{{ .Values.kubePlexImage.repository }}:{{ .Values.kubePlexImage.tag }}"
-        imagePullPolicy: {{ .Values.kubePlexImage.pullPolicy }}
+        image: "{{ .Values.kubePlex.image.repository }}:{{ .Values.kubePlex.image.tag }}"
+        imagePullPolicy: {{ .Values.kubePlex.image.pullPolicy }}
         command:
         - cp
         - /kube-plex

--- a/charts/kube-plex/templates/service.yaml
+++ b/charts/kube-plex/templates/service.yaml
@@ -19,6 +19,10 @@ spec:
   - name: pms
     port: 32400
     targetPort: 32400
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
   selector:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Values file specifies kubePlex.image instead. Fixed.

Feature: Added the ability to specify externalIPs on the service