### PR TITLE
Fix the kube-plex copy script for plexpass images

### DIFF
--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -43,7 +43,13 @@ spec:
 {{- if .Values.kubePlex.enabled }}
         # We replace the PMS binary after plex finishes upgrading
         command: ["/bin/bash"]
-        args: ["-c", "echo \"rm -f '/usr/lib/plexmediaserver/Plex Transcoder' && cp /shared/kube-plex '/usr/lib/plexmediaserver/Plex Transcoder'\" >> /etc/cont-init.d/50-plex-update && /init"]
+        args:
+          - -c
+          - |
+            #!/bin/bash
+            echo "set -e" >> /etc/cont-init.d/50-plex-update
+            echo "rm -f '/usr/lib/plexmediaserver/Plex Transcoder' && cp /shared/kube-plex '/usr/lib/plexmediaserver/Plex Transcoder'" >> /etc/cont-init.d/50-plex-update
+            /init
 {{- end }}
         # readinessProbe:
         #   httpGet:

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -50,8 +50,6 @@ spec:
               - bash
               - -c
               - |
-                #!/bin/bash
-                set -e
                 rm -f '/usr/lib/plexmediaserver/Plex Transcoder'
                 cp /shared/kube-plex '/usr/lib/plexmediaserver/Plex Transcoder'
 {{- end }}

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -41,17 +41,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{- if .Values.kubePlex.enabled }}
-        # We replace the PMS binary with a postStart hook to save having to
-        # modify the default image entrypoint.
-        lifecycle:
-          postStart:
-            exec:
-              command:
-              - bash
-              - -c
-              - |
-                rm -f '/usr/lib/plexmediaserver/Plex Transcoder'
-                cp /shared/kube-plex '/usr/lib/plexmediaserver/Plex Transcoder'
+        # We replace the PMS binary after plex finishes upgrading
+        command: ["/bin/bash"]
+        args: ["-c", "echo \"rm -f '/usr/lib/plexmediaserver/Plex Transcoder' && cp /shared/kube-plex '/usr/lib/plexmediaserver/Plex Transcoder'\" >> /etc/cont-init.d/50-plex-update && /init"]
 {{- end }}
         # readinessProbe:
         #   httpGet:

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -47,8 +47,20 @@ spec:
           - -c
           - |
             #!/bin/bash
+
+            set -e
+
+            # If Plex Transcoder exists then let copy kube-plex now
+            if [ -f '/usr/lib/plexmediaserver/Plex Transcoder' ]; then
+              rm -f '/usr/lib/plexmediaserver/Plex Transcoder'
+              cp /shared/kube-plex '/usr/lib/plexmediaserver/Plex Transcoder'
+            fi
+
+            # either way add the commands to the update script so that after an update it runs again
             echo "set -e" >> /etc/cont-init.d/50-plex-update
-            echo "rm -f '/usr/lib/plexmediaserver/Plex Transcoder' && cp /shared/kube-plex '/usr/lib/plexmediaserver/Plex Transcoder'" >> /etc/cont-init.d/50-plex-update
+            echo "rm -f '/usr/lib/plexmediaserver/Plex Transcoder'" >> /etc/cont-init.d/50-plex-update
+            echo "cp /shared/kube-plex '/usr/lib/plexmediaserver/Plex Transcoder'" >> /etc/cont-init.d/50-plex-update
+
             /init
 {{- end }}
         # readinessProbe:


### PR DESCRIPTION
The script currently set to run as a postStart container fails on the plexpass docker image because there's no plex built-in. This image downloads plex when it starts so that it evergreen. My change here is to add the lines to copy kube-plex to the update script at the end, this way it gets run after plex is installed.