### PR TITLE
service enhancement

### DIFF
--- a/charts/kube-plex/Chart.yaml
+++ b/charts/kube-plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.10.1.4602-f54242b6b
 description: Plex Media Server
 name: kube-plex
-version: 0.2.0
+version: 0.2.1
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -75,11 +75,23 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: TRANSCODE_PVC
-          value: {{ if .Values.persistence.config.claimName }}{{ .Values.persistence.config.claimName }}{{- else }}{{ template "fullname" . }}-transcode{{- end }}
+{{- if .Values.persistence.transcode.claimName }}
+          value: "{{ .Values.persistence.transcode.claimName }}"
+{{- else }}
+          value: "{{ template "fullname" . }}-transcode"
+{{- end }}
         - name: DATA_PVC
-          value: {{ if .Values.persistence.config.claimName }}{{ .Values.persistence.config.claimName }}{{- else }}{{ template "fullname" . }}-data{{- end }}
+{{- if .Values.persistence.data.claimName }}
+          value: "{{ .Values.persistence.data.claimName }}"
+{{- else }}
+          value: "{{ template "fullname" . }}-data"
+{{- end }}
         - name: CONFIG_PVC
-          value: {{ if .Values.persistence.config.claimName }}{{ .Values.persistence.config.claimName }}{{- else }}{{ template "fullname" . }}-config{{- end }}
+{{- if .Values.persistence.config.claimName }}
+          value: "{{ .Values.persistence.config.claimName }}"
+{{- else }}
+          value: "{{ template "fullname" . }}-config"
+{{- end }}
         volumeMounts:
         - name: data
           mountPath: /data

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -59,6 +59,13 @@ spec:
         #   httpGet:
         #     path: /
         #     port: 32400
+        ports:
+          - name: pms
+            containerPort: 32400
+          - name: http
+            containerPort: 32400
+          - name: https
+            containerPort: 32443
         env:
         - name: TZ
           value: "{{ .Values.timezone }}"

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -75,23 +75,11 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: TRANSCODE_PVC
-{{- if .Values.persistence.transcode.claimName }}
-          value: "{{ .Values.persistence.transcode.claimName }}"
-{{- else }}
-          value: "{{ template "fullname" . }}-transcode"
-{{- end }}
+          value: {{ if .Values.persistence.config.claimName }}{{ .Values.persistence.config.claimName }}{{- else }}{{ template "fullname" . }}-transcode{{- end }}
         - name: DATA_PVC
-{{- if .Values.persistence.data.claimName }}
-          value: "{{ .Values.persistence.data.claimName }}"
-{{- else }}
-          value: "{{ template "fullname" . }}-data"
-{{- end }}
+          value: {{ if .Values.persistence.config.claimName }}{{ .Values.persistence.config.claimName }}{{- else }}{{ template "fullname" . }}-data{{- end }}
         - name: CONFIG_PVC
-{{- if .Values.persistence.config.claimName }}
-          value: "{{ .Values.persistence.config.claimName }}"
-{{- else }}
-          value: "{{ template "fullname" . }}-config"
-{{- end }}
+          value: {{ if .Values.persistence.config.claimName }}{{ .Values.persistence.config.claimName }}{{- else }}{{ template "fullname" . }}-config{{- end }}
         volumeMounts:
         - name: data
           mountPath: /data

--- a/charts/kube-plex/templates/ingress.yaml
+++ b/charts/kube-plex/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
           - path: /
             backend:
               serviceName: {{ $serviceName }}
-              servicePort: {{ .Values.service.port }}
+              servicePort: pms
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/kube-plex/templates/ingress.yaml
+++ b/charts/kube-plex/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
           - path: /
             backend:
               serviceName: {{ $serviceName }}
-              servicePort: 32400
+              servicePort: {{ .Values.service.port }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/kube-plex/templates/service.yaml
+++ b/charts/kube-plex/templates/service.yaml
@@ -7,6 +7,52 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.service.type "LoadBalancer" }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.type }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.service.externalIPs | indent 4 }}
+{{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - name: pms
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: pms
+{{ if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+      nodePort: {{.Values.service.nodePort}}
+{{ end }}
+    - name: http
+      port: 80
+      targetPort: pms
+    - name: https
+      port: 443
+      targetPort: 32443
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -26,3 +72,4 @@ spec:
   selector:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}
+

--- a/charts/kube-plex/templates/service.yaml
+++ b/charts/kube-plex/templates/service.yaml
@@ -53,22 +53,6 @@ spec:
     - name: https
       port: 443
       targetPort: 32443
-spec:
-  type: {{ .Values.service.type }}
-  ports:
-  - name: http
-    port: 80
-    targetPort: 32400
-  - name: https
-    port: 443
-    targetPort: 32443
-  - name: pms
-    port: 32400
-    targetPort: 32400
-{{- if .Values.service.externalIPs }}
-  externalIPs:
-{{ toYaml .Values.service.externalIPs | indent 4 }}
-{{- end }}
   selector:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -21,6 +21,24 @@ timezone: Europe/London
 
 service:
   type: ClusterIP
+  port: 32400
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  # nodePort:
+  ## Provide any additional annotations which may be required. This can be used to
+  ## set the LoadBalancer service type to internal only.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  annotations: {}
+  labels: {}
+  ## Use loadBalancerIP to request a specific static IP,
+  ## otherwise leave blank
+  ##
+  loadBalancerIP:
+  # loadBalancerSourceRanges: []
+  ## Set the externalTrafficPolicy in the Service to either Cluster or Local
+  # externalTrafficPolicy: Cluster
 
 ingress:
   enabled: false


### PR DESCRIPTION
This PR is to enable more configuration options for the Plex service.

This will allow a user to specify,

* optional listening port override (defaulting to 32400)
* optional hardcoded `nodePort` when nodePort is the service type selected
* optional annotations and labels for the service
* optional hardcoded `loadBalancerIP` for when LoadBalancer is the service type selected
* optional hardcoded `loadBalancerSourceRanges` for when LoadBalancer is the service type selected
* optional `externalTrafficPolicy` to be either Cluster or Local
