### PR TITLE
different persistence accessmodes for config files

### DIFF
--- a/charts/kube-plex/Chart.yaml
+++ b/charts/kube-plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.10.1.4602-f54242b6b
 description: Plex Media Server
 name: kube-plex
-version: 0.2.1
+version: 0.2.3
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/kube-plex/templates/volumes.yaml
+++ b/charts/kube-plex/templates/volumes.yaml
@@ -33,7 +33,7 @@ metadata:
     component: config
 spec:
   accessModes:
-  - ReadWriteMany
+  - {{ .Values.persistence.config.accessMode | quote }}
   resources:
     requests:
       storage: {{ .Values.persistence.config.size | quote }}

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -103,6 +103,7 @@ persistence:
     # The requested size of the volume to be used when creating a
     # PersistentVolumeClaim.
     size: 20Gi
+    accessMode: ReadWriteOnce
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -103,7 +103,7 @@ persistence:
     # The requested size of the volume to be used when creating a
     # PersistentVolumeClaim.
     size: 20Gi
-    accessMode: ReadWriteOnce
+    accessMode: ReadWriteMany
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Certain backend storage solutions (e.g. ceph rbd) don't allow ReadWriteMany accessModes.

The purpose of this PR is to allow users to choose the accessMode they want to use.