### PR TITLE
Updating plex media server to 1.16.0.1226-7eb2c8f6f

### DIFF
--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: plexinc/pms-docker
-  tag: 1.10.1.4602-f54242b6b
+  tag: 1.16.0.1226-7eb2c8f6f
   pullPolicy: IfNotPresent
 
 kubePlex:


### PR DESCRIPTION
This PR will update Plex Media Server to the most recent version that was released `1.16.0.1226-7eb2c8f6f`