### PR TITLE
Applying fix for helm NOTES.txt file for ClusterIP and LoadBalancer

### DIFF
--- a/charts/kube-plex/templates/NOTES.txt
+++ b/charts/kube-plex/templates/NOTES.txt
@@ -11,9 +11,10 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+  export SERVICE_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.spec.ports[1].port}')
+  echo http://$SERVICE_IP:$SERVICE_PORT
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.port }}
 {{- end }}

--- a/main.go
+++ b/main.go
@@ -139,9 +139,7 @@ func generatePod(cwd string, env []string, args []string) *corev1.Pod {
 				{
 					Name: "data",
 					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: dataPVC,
-						},
+						HostPath: &corev1.HostPathVolumeSource{Path: "/mnt/disks/gdrive"},
 					},
 				},
 				{


### PR DESCRIPTION
This PR fixes the commands outputted from helm `NOTES.txt` file for service type ClusterIP and LoadBalancer. This should allow a user to copy and export the IP and PORT and access it either via ClusterIP or from the LoadBalancers IP address