### PR TITLE
Turn the ClaimToken into a K8s Secret

### DIFF
--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -37,11 +37,11 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `persistence.transcode.subPath` | SubPath to use for existing Claim | `nil` |
 | `persistence.transcode.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.data.size`         | Size of persistent volume claim | `40Gi` |
-| `persistence.data.existingClaim`| Use an existing PVC to persist data | `nil` |
+| `persistence.data.claimName`| Use an existing PVC to persist data | `nil` |
 | `persistence.data.subPath` | SubPath to use for existing Claim | `nil` |
 | `persistence.data.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.config.size`         | Size of persistent volume claim | `20Gi` |
-| `persistence.config.existingClaim`| Use an existing PVC to persist data | `nil` |
+| `persistence.config.claimName`| Use an existing PVC to persist data | `nil` |
 | `persistence.config.subPath` | SubPath to use for existing Claim | `nil` |
 | `persistence.config.storageClass` | Type of persistent volume claim | `-` |
 | `resources`                | CPU/Memory resource requests/limits | `{}` |

--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -13,8 +13,8 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `kubePlex.image.repository`         | Image repository | `quay.io/munnerz/kube-plex` |
 | `kubePlex.image.tag`                | Image tag. | `latest`|
 | `kubePlex.image.pullPolicy`         | Image pull policy | `IfNotPresent` |
-| `claimToken.secret`                 | Premade secret holding the Plex Claim Token to authenticate your acount. Must set this or `claimToken.value` | `` |
-| `claimToken.secretKey`                 | The key in the above secret that holds the Plex Claim Toke | `claimToken` |
+| `claimToken.secret`                 | Existing secret name holding the Plex Claim Token to authenticate your acount. Must set this or `claimToken.value` | `` |
+| `claimToken.secretKey`                 | The key in the above secret that holds the Plex Claim Token | `claimToken` |
 | `claimToken.value`                 | The plain-text Plex Claim Token. Set this if not using `claimToken.secret` | `` |
 | `timezone`                 | Timezone plex instance should run as, e.g. 'America/New_York' | `Europe/London` |
 | `service.type`          | Kubernetes service type for the plex GUI/API | `ClusterIP` |

--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -13,7 +13,9 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `kubePlex.image.repository`         | Image repository | `quay.io/munnerz/kube-plex` |
 | `kubePlex.image.tag`                | Image tag. | `latest`|
 | `kubePlex.image.pullPolicy`         | Image pull policy | `IfNotPresent` |
-| `claimToken`                 | Plex Claim Token to authenticate your acount | `` |
+| `claimToken.secret`                 | Premade secret holding the Plex Claim Token to authenticate your acount. Must set this or `claimToken.value` | `` |
+| `claimToken.secretKey`                 | The key in the above secret that holds the Plex Claim Toke | `claimToken` |
+| `claimToken.value`                 | The plain-text Plex Claim Token. Set this if not using `claimToken.secret` | `` |
 | `timezone`                 | Timezone plex instance should run as, e.g. 'America/New_York' | `Europe/London` |
 | `service.type`          | Kubernetes service type for the plex GUI/API | `ClusterIP` |
 | `service.port`          | Kubernetes port where the plex GUI/API is exposed| `32400` |

--- a/charts/kube-plex/templates/_helpers.tpl
+++ b/charts/kube-plex/templates/_helpers.tpl
@@ -14,3 +14,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the secret name for the claimToken
+*/}}
+{{- define "claimTokenSecretName" -}}
+{{- if .Values.claimToken.secret -}}
+    {{ printf "%s" .Values.claimToken.secret }}
+{{- else -}}
+    {{ printf "%s-%s" (include "fullname" .) "claim-token" | trunc 63 -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -83,9 +83,11 @@ spec:
         env:
         - name: TZ
           value: "{{ .Values.timezone }}"
-        # TODO: move this to a secret?
         - name: PLEX_CLAIM
-          value: "{{ .Values.claimToken }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "claimTokenSecretName" . }}
+              key: {{ .Values.claimToken.secretKey }}
         # kube-plex env vars
         - name: PMS_INTERNAL_ADDRESS
           value: http://{{ template "fullname" . }}:32400

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -83,6 +83,10 @@ spec:
         env:
         - name: TZ
           value: "{{ .Values.timezone }}"
+        - name: PLEX_CLAIM_SECRET_NAME
+          value: {{ template "claimTokenSecretName" . }}
+        - name: PLEX_CLAIM_SECRET_KEY
+          value: {{ .Values.claimToken.secretKey }}
         - name: PLEX_CLAIM
           valueFrom:
             secretKeyRef:

--- a/charts/kube-plex/templates/secret-claimToken.yaml
+++ b/charts/kube-plex/templates/secret-claimToken.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.claimToken.secret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "claimTokenSecretName" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{ .Values.claimToken.secretKey }}: {{ .Values.claimToken.value | b64enc | quote }}
+{{- end -}}

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -14,7 +14,12 @@ kubePlex:
     pullPolicy: Always
 
 # Override this with the plex claim token from plex.tv/claim
-claimToken: ""
+claimToken:
+  ## secret containing your claimToken. if not set it will create a secret instead using claimToken.value
+  secret:
+  secretKey: claimToken
+  ## only specify value if you are passing in the plain text claimToken
+  value:
 
 # Set the timezone of the plex server
 timezone: Europe/London


### PR DESCRIPTION
Great chart/tool, thanks for making this!

I use a GitOps approach for my cluster deployments, and didn't want to commit the claimToken in plain text to a git repo. So I decided to break it out into a secret!

This PR will allow the end user to specify either the name of an existing secret or still pass the plain text version and the secret will be made for them.

Feel free to make any suggestions and I can make changes or you can make any necessary changes yourself.