### PR TITLE
Add affinity and tolerations

### DIFF
--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -48,5 +48,7 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `proxy.http`           | HTTP_PROXY value 'http://proxy.lan:8080'  | `{}` |
 | `proxy.https`           | HTTPS_PROXY value 'http://proxy.lan:8080'  | `{}` |
 | `proxy.noproxy`           | NO_PROXY value 'localhost,127.0.0.1,10.96.0.0/12,10.244.0.0/12'  | `{}` |
+| `tolerations`           | Pod tolerations  | `[]` |
+| `affinity`           | Pod affinity configuration  | `{}` |
 
 Read through the [values.yaml](values.yaml) file. It has several commented out suggested values.

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -179,3 +179,11 @@ spec:
 {{- end }}
       - name: shared
         emptyDir: {}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -125,3 +125,10 @@ proxy:
   # http: "http://proxy:8080"
   # https: "https://proxy:8080"
   # noproxy: "localhost,127.0.0.1,10.96.0.0/12,10.244.0.0/12"
+
+
+# allows setting which taints kubeplex tolerates
+tolerations: []
+
+# allows specifying node affinity
+affinity: {}


### PR DESCRIPTION
This is useful when running on clusters with more than one worker where one would like to pin plex to a specific node.