### PR TITLE
Adding in option for additional mounts

### DIFF
--- a/charts/kube-plex/Chart.yaml
+++ b/charts/kube-plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0.1226-7eb2c8f6f
 description: Plex Media Server
 name: kube-plex
-version: 0.2.5
+version: 0.2.6
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -39,6 +39,7 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `persistence.data.subPath` | SubPath to use for existing Claim | `nil` |
 | `persistence.data.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.data.accessMode` | Persistent volume access mode | `ReadWriteMany` |
+| `persistence.extraData` | Extra data mounts.  Should be an array of items matching persistence.data entries | `[]` |
 | `persistence.config.size`         | Size of persistent volume claim | `20Gi` |
 | `persistence.config.claimName`| Use an existing PVC to persist data | `nil` |
 | `persistence.config.subPath` | SubPath to use for existing Claim | `nil` |

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -143,6 +143,10 @@ spec:
         {{- if .Values.persistence.transcode.subPath }}
           subPath: {{ .Values.persistence.transcode.subPath }}
         {{ end }}
+        {{-  range .Values.persistence.extraData }}
+        - mountPath: "/data-{{ .name }}"
+          name: "extradata-{{ .name }}"
+        {{- end }}
         - name: shared
           mountPath: /shared
         resources:
@@ -176,6 +180,15 @@ spec:
 {{- end }}
 {{- else }}
         emptyDir: {}
+{{- end }}
+{{-  range .Values.persistence.extraData }}
+      - name: "extradata-{{ .name }}"
+        persistentVolumeClaim:
+{{- if .claimName }}
+          claimName: "{{ .claimName }}"
+{{- else }}
+          claimName: "extradata-{{ .name }}"
+{{- end }}
 {{- end }}
       - name: shared
         emptyDir: {}

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -92,6 +92,13 @@ persistence:
     size: 40Gi
     # Access mode for this volume
     accessMode: ReadWriteMany
+  extraData: []
+    # Optionally specifify additional Data mounts.  These will be mounted as
+    # /data-${name}.  This should be in the same format as the above 'data', 
+    # with the additional field 'name'
+    # - claimName: "special-tv"
+    #   name: 'foo'
+
   config:
     # Optionally specify claimName to manually override the PVC to be used for
     # the config directory. If claimName is specified, storageClass and size


### PR DESCRIPTION
Hello!  This is a pull request that enables additional mounts beyond a single /data.  I've got a use case where I have a few different NFS mounts with multiple types of media that I would like to have available for the plex container.  Hopefully this is useful for others too.  Thanks!