### PR TITLE
Add container environment  variables supported by official Plex docker image

### DIFF
--- a/charts/kube-plex/Chart.yaml
+++ b/charts/kube-plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0.1226-7eb2c8f6f
 description: Plex Media Server
 name: kube-plex
-version: 0.2.7
+version: 0.2.8
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/kube-plex/Chart.yaml
+++ b/charts/kube-plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0.1226-7eb2c8f6f
 description: Plex Media Server
 name: kube-plex
-version: 0.2.10
+version: 0.2.11
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/kube-plex/Chart.yaml
+++ b/charts/kube-plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0.1226-7eb2c8f6f
 description: Plex Media Server
 name: kube-plex
-version: 0.2.8
+version: 0.2.9
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/kube-plex/Chart.yaml
+++ b/charts/kube-plex/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0.1226-7eb2c8f6f
 description: Plex Media Server
 name: kube-plex
-version: 0.2.9
+version: 0.2.10
 keywords:
   - plex
 home: https://plex.tv/

--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -15,6 +15,11 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `kubePlex.image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `claimToken`                 | Plex Claim Token to authenticate your acount | `` |
 | `timezone`                 | Timezone plex instance should run as, e.g. 'America/New_York' | `Europe/London` |
+| `allowed_networks`                 | List of IP addresses and networks that are allowed without auth' | `nil` |
+| `change_config_dir_ownership`                 | Instruct the Plex Media Server Container to Change the Configuration Directory Ownership | `nil` |
+| `advertise_ip`                 | This adds to the list where the server advertises that it can be found.' | `nil` |
+| `plex_uid`                 | The user id of the plex user created inside the container' | `nil` |
+| `plex_gid`                 | The group id of the plex group created inside the container | `nil` |
 | `service.type`          | Kubernetes service type for the plex GUI/API | `ClusterIP` |
 | `service.port`          | Kubernetes port where the plex GUI/API is exposed| `32400` |
 | `service.annotations`   | Service annotations for the Plex GUI | `{}` |

--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -35,6 +35,11 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `ingress.tls`                  | Ingress TLS configuration | `[]` |
 | `rbac.create`                  | Create RBAC roles? | `true` |
 | `nodeSelector`             | Node labels for pod assignment | `beta.kubernetes.io/arch: amd64` |
+| `configMap.plexPreferences.enabled`             | Enable init script(and load configMap) that will read all environment variables starting with PLEX_PREFERENCE_ | `false` |
+| `configMap.plexPreferences.name`             | Name of configMap | `41-plex-preferences` |
+| `configMap.plexPreferences.defaultMode`             | Unix permissions in container (0755) | `493` |
+| `configMap.plexPreferences.mountPath`             | The full path to the file we will mount the configMap to | `/etc/cont-init.d/41-plex-preferences` |
+| `configMap.plexPreferences.subPath`             | And use subpath to mount it as an individual file not a volume  | `41-plex-preferences` |
 | `persistence.transcode.enabled`      | Use persistent volume for transcoding | `false` |
 | `persistence.transcode.size`         | Size of persistent volume claim | `20Gi` |
 | `persistence.transcode.claimName`| Use an existing PVC to persist data | `nil` |

--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -15,11 +15,11 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `kubePlex.image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `claimToken`                 | Plex Claim Token to authenticate your acount | `` |
 | `timezone`                 | Timezone plex instance should run as, e.g. 'America/New_York' | `Europe/London` |
-| `allowed_networks`                 | List of IP addresses and networks that are allowed without auth' | `nil` |
-| `change_config_dir_ownership`                 | Instruct the Plex Media Server Container to Change the Configuration Directory Ownership | `nil` |
-| `advertise_ip`                 | This adds to the list where the server advertises that it can be found.' | `nil` |
-| `plex_uid`                 | The user id of the plex user created inside the container' | `nil` |
-| `plex_gid`                 | The group id of the plex group created inside the container | `nil` |
+| `allowedNetworks`                 | List of IP addresses and networks that are allowed without auth' | `nil` |
+| `changeConfigDirOwnership`                 | Instruct the Plex Media Server Container to Change the Configuration Directory Ownership | `nil` |
+| `advertiseIp`                 | This adds to the list where the server advertises that it can be found.' | `nil` |
+| `plexUid`                 | The user id of the plex user created inside the container' | `nil` |
+| `plexGid`                 | The group id of the plex group created inside the container | `nil` |
 | `service.type`          | Kubernetes service type for the plex GUI/API | `ClusterIP` |
 | `service.port`          | Kubernetes port where the plex GUI/API is exposed| `32400` |
 | `service.annotations`   | Service annotations for the Plex GUI | `{}` |

--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -41,6 +41,7 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `persistence.transcode.subPath` | SubPath to use for existing Claim | `nil` |
 | `persistence.transcode.storageClass` | Type of persistent volume claim | `-` |
 | `persistence.transcode.accessMode` | Persistent volume access mode | `ReadWriteMany` |
+| `persistence.transcode.emptyDir.medium` | Set this if you want to use tmpfs (in-memory) file system for /transcode | `Memory` |
 | `persistence.data.size`         | Size of persistent volume claim | `40Gi` |
 | `persistence.data.claimName`| Use an existing PVC to persist data | `nil` |
 | `persistence.data.subPath` | SubPath to use for existing Claim | `nil` |

--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -20,6 +20,7 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `advertiseIp`                 | This adds to the list where the server advertises that it can be found.' | `nil` |
 | `plexUid`                 | The user id of the plex user created inside the container' | `nil` |
 | `plexGid`                 | The group id of the plex group created inside the container | `nil` |
+| `extraEnv`                 | Pass arbitrary environment variables to the Plex container as a map. See values.yaml for details | `nil` |
 | `service.type`          | Kubernetes service type for the plex GUI/API | `ClusterIP` |
 | `service.port`          | Kubernetes port where the plex GUI/API is exposed| `32400` |
 | `service.annotations`   | Service annotations for the Plex GUI | `{}` |

--- a/charts/kube-plex/configs/41-plex-preferences
+++ b/charts/kube-plex/configs/41-plex-preferences
@@ -1,0 +1,57 @@
+#!/usr/bin/with-contenv bash
+# This file is based off of the official 40-plex-first-run 
+# Here: https://github.com/plexinc/pms-docker/blob/master/root/etc/cont-init.d/40-plex-first-run
+# It should live in /etc/cont-init.d/
+
+# If we are debugging, enable trace
+if [ "${DEBUG,,}" = "true" ]; then
+  set -x
+fi
+
+function setPref {
+  local key="$1"
+  local value="$2"
+  
+  count="$(xmlstarlet sel -t -v "count(/Preferences/@${key})" "${prefFile}")"
+  count=$(($count + 0))
+  if [[ $count > 0 ]]; then
+    xmlstarlet ed --inplace --update "/Preferences/@${key}" -v "${value}" "${prefFile}"
+  else
+    xmlstarlet ed --inplace --insert "/Preferences"  --type attr -n "${key}" -v "${value}" "${prefFile}"
+  fi
+}
+
+home="$(echo ~plex)"
+pmsApplicationSupportDir="${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR:-${home}/Library/Application Support}"
+prefFile="${pmsApplicationSupportDir}/Plex Media Server/Preferences.xml"
+
+if [ ! -z "${ADVERTISE_IP}" ]; then
+  setPref "customConnections" "${ADVERTISE_IP}"
+fi
+
+if [ ! -z "${ALLOWED_NETWORKS}" ]; then
+  setPref "allowedNetworks" "${ALLOWED_NETWORKS}"
+fi
+
+# Set transcoder temp if not yet set
+if [ -z "$(getPref "TranscoderTempDirectory")" ]; then
+  setPref "TranscoderTempDirectory" "/transcode"
+fi
+
+# Parse list of all exported variables that start with PLEX_PREFERENCE_
+# The format of which is PLEX_PREFERENCE_IDENTIFIER="Key=Value"
+# Where Key is the EXACT key to use in the Plex Preference file
+# And Value is the EXACT value to use in the Plex Preference file for that key.
+# Please note it looks like many of the key's are camelCase in some fashion.
+# Additionally there are likely some preferences where environment variable injection
+# doesn't really work for.
+for var in "${!PLEX_PREFERENCE_@}"; do
+  value=${!var}
+  PreferenceValue=${value#*=}
+  PreferenceKey=${value%=*}
+  setPref $PreferenceKey $PreferenceValue
+done
+
+# touch /.firstRunComplete
+# echo "Plex Media Server first run setup complete"
+echo "Plex Media Server preferences update run complete"

--- a/charts/kube-plex/templates/_helpers.tpl
+++ b/charts/kube-plex/templates/_helpers.tpl
@@ -14,3 +14,21 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+abstract: |
+  Joins a list of values into a comma separated string
+values: |
+  test:
+    - foo
+    - bar
+usage: |
+  {{ include "joinListWithComma" .Values.test }}
+return: |
+  foo,bar
+*/}}
+
+{{- define "joinListWithComma" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}

--- a/charts/kube-plex/templates/configmap.yaml
+++ b/charts/kube-plex/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.configMap.plexPreferences.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.configMap.plexPreferences.name }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+
+data:
+# At some point figure out how to use a value/Variable here to be able to specify 
+# a different file or something.
+{{ (tpl (.Files.Glob "configs/41-plex-preferences").AsConfig . ) | indent 2 }}
+{{- end -}}

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -182,6 +182,11 @@ spec:
         {{- end }}
         - name: shared
           mountPath: /shared
+{{- if .Values.configMap.plexPreferences.enabled }}
+        - name: {{ .Values.configMap.plexPreferences.name }}
+          mountPath: {{ .Values.configMap.plexPreferences.mountPath }}
+          subPath: {{ .Values.configMap.plexPreferences.subPath }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.nodeSelector }}
@@ -189,6 +194,12 @@ spec:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
       volumes:
+{{- if .Values.configMap.plexPreferences.enabled }}
+      - name: {{ .Values.configMap.plexPreferences.name }}
+        configMap:
+          name: {{ .Values.configMap.plexPreferences.name }}
+          defaultMode: {{ .Values.configMap.plexPreferences.defaultMode }}
+{{- end }}
       - name: data
         persistentVolumeClaim:
 {{- if .Values.persistence.data.claimName }}

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -212,7 +212,12 @@ spec:
           claimName: "{{ template "fullname" . }}-transcode"
 {{- end }}
 {{- else }}
+{{- if .Values.persistence.transcode.emptyDir.medium }}
+        emptyDir: 
+          medium: "{{ .Values.persistence.transcode.emptyDir.medium }}"
+{{- else }}
         emptyDir: {}          
+{{- end }}
 {{- end }}
 {{-  range .Values.persistence.extraData }}
       - name: "extradata-{{ .name }}"

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -135,25 +135,25 @@ spec:
   {{- end }}
 {{- end }}
 # Official kube-plex container environment variables
-{{- if .Values.advertise_ip }}
+{{- if .Values.advertiseIp }}
         - name: "ADVERTISE_IP"
-          value: "{{.Values.advertise_ip}}"
+          value: "{{.Values.advertiseIp}}"
 {{- end }}
-{{- if .Values.change_config_dir_ownership }}
+{{- if .Values.changeConfigDirOwnership }}
         - name: "CHANGE_CONFIG_DIR_OWNERSHIP"
-          value: "{{.Values.change_config_dir_ownership}}"
+          value: "{{.Values.changeConfigDirOwnership}}"
 {{- end }}
-{{- if .Values.allowed_networks }}
+{{- if .Values.allowedNetworks }}
         - name: "ALLOWED_NETWORKS"
-          value: "{{include "joinListWithComma" .Values.allowed_networks}}"
+          value: "{{include "joinListWithComma" .Values.allowedNetworks}}"
 {{- end }}
-{{- if .Values.plex_uid }}
+{{- if .Values.plexUid }}
         - name: "PLEX_UID"
-          value: "{{.Values.plex_uid}}"
+          value: "{{.Values.plexUid}}"
 {{- end }}
-{{- if .Values.plex_gid }}
+{{- if .Values.plexGid }}
         - name: "PLEX_GID"
-          value: "{{.Values.plex_gid}}"
+          value: "{{.Values.plexGid}}"
 {{- end }}
         volumeMounts:
         - name: data

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -134,6 +134,27 @@ spec:
           value: "{{.Values.proxy.noproxy}}"
   {{- end }}
 {{- end }}
+# Official kube-plex container environment variables
+{{- if .Values.advertise_ip }}
+        - name: "ADVERTISE_IP"
+          value: "{{.Values.advertise_ip}}"
+{{- end }}
+{{- if .Values.change_config_dir_ownership }}
+        - name: "CHANGE_CONFIG_DIR_OWNERSHIP"
+          value: "{{.Values.change_config_dir_ownership}}"
+{{- end }}
+{{- if .Values.allowed_networks }}
+        - name: "ALLOWED_NETWORKS"
+          value: "{{include "joinListWithComma" .Values.allowed_networks}}"
+{{- end }}
+{{- if .Values.plex_uid }}
+        - name: "PLEX_UID"
+          value: "{{.Values.plex_uid}}"
+{{- end }}
+{{- if .Values.plex_gid }}
+        - name: "PLEX_GID"
+          value: "{{.Values.plex_gid}}"
+{{- end }}
         volumeMounts:
         - name: data
           mountPath: /data

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -155,6 +155,11 @@ spec:
         - name: "PLEX_GID"
           value: "{{.Values.plexGid}}"
 {{- end }}
+# Extra ENV Values supplied by user
+{{- range $key, $value := .Values.extraEnv }}
+        - name: {{ $key }}
+          value: {{ $value }}
+{{- end }}
         volumeMounts:
         - name: data
           mountPath: /data
@@ -207,7 +212,7 @@ spec:
           claimName: "{{ template "fullname" . }}-transcode"
 {{- end }}
 {{- else }}
-        emptyDir: {}
+        emptyDir: {}          
 {{- end }}
 {{-  range .Values.persistence.extraData }}
       - name: "extradata-{{ .name }}"

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -95,6 +95,25 @@ rbac:
 nodeSelector:
   beta.kubernetes.io/arch: amd64
 
+configMap:
+  # Enable init script that will read all environment variables starting with PLEX_PREFERENCE_
+  # and take the value as the Key:Value option to set in Plex Preference.xml
+  # You can use extraEnv to add the addtional ENV's to the container.
+  # --set extraEnv.PLEX_PREFERENCE_1="FriendlyName=plex-kube-plex-test1" `
+  # --set extraEnv.PLEX_PREFERENCE_2="EnableIPv6=0" `
+  # --set extraEnv.PLEX_PREFERENCE_3="logDebug=0" `
+  # --set extraEnv.PLEX_PREFERENCE_4="DisableTLSv1_0=1" `
+  # --set extraEnv.PLEX_PREFERENCE_5="LanNetworksBandwidth=xxx.xxx.xxx.0/18\,xxx.xxx.xxx.0/24\,xxx.xxx.xxx.0/24" `
+  # --set extraEnv.PLEX_PREFERENCE_6="TranscoderQuality=2" `
+  # --set extraEnv.PLEX_PREFERENCE_7="TreatWanIpAsLocal=0" `
+  # --set extraEnv.PLEX_PREFERENCE_8="TranscoderH264BackgroundPreset=fast" 
+  plexPreferences:
+    enabled: false
+    name: 41-plex-preferences
+    defaultMode: 493
+    mountPath: /etc/cont-init.d/41-plex-preferences
+    subPath: 41-plex-preferences
+
 persistence:
   transcode:
     # We want to enable a transcode pvc

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -22,28 +22,28 @@ timezone: Europe/London
 # add your pod network subnet to the `List of IP addresses and networks that are allowed without auth`
 # This will override the manual settings, so only use this if you will not need to change it manually.
 # This list will be automatically converted to a command seperated string when passed to the container.
-# You would specify this when using helm CLI with --set allowed_networks="{127.0.0.1,10.54.2.0/24}"
-# allowed_networks: 
+# You would specify this when using helm CLI with --set allowedNetworks="{127.0.0.1,10.54.2.0/24}"
+# allowedNetworks: 
 #   -   127.0.0.1
 #   -   10.54.2.0/24
 
 # Instruct the Plex Media Server Container to Change the Configuration Directory Ownership
 # Default is true, you would only need to set this if you want to disable it.
-# change_config_dir_ownership: true
+# changeConfigDirOwnership: true
 
-# ADVERTISE_IP This variable defines the additional IPs on which the server may be be found. 
+# advertiseIp This variable defines the additional IPs on which the server may be be found. 
 # For example: http://10.1.1.23:32400. 
 # This adds to the list where the server advertises that it can be found.
 # See https://hub.docker.com/r/plexinc/pms-docker/ for details
-# advertise_ip: "http://10.1.1.23:32400"
+# advertiseIp: "http://10.1.1.23:32400"
 
 # Set The user id of the plex user created inside the container.
 # See https://hub.docker.com/r/plexinc/pms-docker/ for details
-# plex_uid: 1000
+# plexUid: 1000
 
 # Set The group id of the plex group created inside the container
 # See https://hub.docker.com/r/plexinc/pms-docker/ for details
-# plex_gid: 1000
+# plexGid: 1000
 
 service:
   type: ClusterIP

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -113,6 +113,11 @@ persistence:
     size: 20Gi
     # Access mode for this volume
     accessMode: ReadWriteMany
+    # If not using a transcode PVC, specify emptyDir.medium="Memory" to use a tmpfs (in-memory)
+    # Volume for /transcode. Warning! this will greatly increase the amount of memory the plex pod is using
+    # AND it will count toward any ram pod/namespace limits.
+    # emptyDir:
+    #   medium: "Memory"
   data:
     # Optionally specify claimName to manually override the PVC to be used for
     # the data directory. If claimName is specified, storageClass and size are

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -45,6 +45,12 @@ timezone: Europe/London
 # See https://hub.docker.com/r/plexinc/pms-docker/ for details
 # plexGid: 1000
 
+# You can add Additional ENV variables here
+# The following is the same as --set extraEnv.TMPDIR="/transcode" 
+# extraEnv:
+#   TMPDIR: /transcode
+
+  
 service:
   type: ClusterIP
   port: 32400
@@ -91,6 +97,8 @@ nodeSelector:
 
 persistence:
   transcode:
+    # We want to enable a transcode pvc
+    enabled: false
     # Optionally specify claimName to manually override the PVC to be used for
     # the transcode directory. If claimName is specified, storageClass and size
     # are ignored.

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -19,6 +19,32 @@ claimToken: ""
 # Set the timezone of the plex server
 timezone: Europe/London
 
+# add your pod network subnet to the `List of IP addresses and networks that are allowed without auth`
+# This will override the manual settings, so only use this if you will not need to change it manually.
+# This list will be automatically converted to a command seperated string when passed to the container.
+# You would specify this when using helm CLI with --set allowed_networks="{127.0.0.1,10.54.2.0/24}"
+# allowed_networks: 
+#   -   127.0.0.1
+#   -   10.54.2.0/24
+
+# Instruct the Plex Media Server Container to Change the Configuration Directory Ownership
+# Default is true, you would only need to set this if you want to disable it.
+# change_config_dir_ownership: true
+
+# ADVERTISE_IP This variable defines the additional IPs on which the server may be be found. 
+# For example: http://10.1.1.23:32400. 
+# This adds to the list where the server advertises that it can be found.
+# See https://hub.docker.com/r/plexinc/pms-docker/ for details
+# advertise_ip: "http://10.1.1.23:32400"
+
+# Set The user id of the plex user created inside the container.
+# See https://hub.docker.com/r/plexinc/pms-docker/ for details
+# plex_uid: 1000
+
+# Set The group id of the plex group created inside the container
+# See https://hub.docker.com/r/plexinc/pms-docker/ for details
+# plex_gid: 1000
+
 service:
   type: ClusterIP
   port: 32400


### PR DESCRIPTION
I added support for a number of environment variables supported by the latest official plex container. I added them as optional, so if not specified would not be added or have a default, and added them explicitly. It looked like the current coding pattern was to specify the env options explicitly vs use a generic "pass any env to the container" method.

Thanks for the hard work in creating the helm chart in the first place, as well as the transcoder.