### PR TITLE
Make NodePort deployment discoverable

### DIFF
--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
           - name: https
             containerPort: 32443
         env:
+{{- if .Values.discovery.enabled }}
+        - name: ADVERTISE_IP
+          value: https://{{ .Values.discovery.ip }}:{{ .Values.service.nodePort }}
+{{- end }}
         - name: TZ
           value: "{{ .Values.timezone }}"
         # TODO: move this to a secret?

--- a/charts/kube-plex/templates/ingress.yaml
+++ b/charts/kube-plex/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}

--- a/charts/kube-plex/templates/ingress.yaml
+++ b/charts/kube-plex/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}
@@ -20,9 +20,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: pms
+              service:
+                name: {{ $serviceName }}
+                port:
+                  name: pms
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/kube-plex/templates/service.yaml
+++ b/charts/kube-plex/templates/service.yaml
@@ -53,6 +53,28 @@ spec:
     - name: https
       port: 443
       targetPort: 32443
+{{- if .Values.discovery.enabled }}
+    - name: udp1
+      nodePort: 32410
+      port: 32410
+      protocol: UDP
+      targetPort: 32410
+    - name: udp2
+      nodePort: 32412
+      port: 32412
+      protocol: UDP
+      targetPort: 32412
+    - name: udp3
+      nodePort: 32413
+      port: 32413
+      protocol: UDP
+      targetPort: 32413
+    - name: udp4
+      nodePort: 32414
+      port: 32414
+      protocol: UDP
+      targetPort: 32414
+{{- end }}
   selector:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
When deploying as NodePort, add UDP ports for server discovery.